### PR TITLE
feature: Add centralized schema package for multi-app access

### DIFF
--- a/apps/api/eslint.config.cjs
+++ b/apps/api/eslint.config.cjs
@@ -24,16 +24,18 @@ module.exports = [
         describe: 'readonly',
         it: 'readonly',
         expect: 'readonly',
-        test: 'readonly'
+        test: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
       }
     },
     plugins: {
-      '@typescript-eslint': typescript
+      '@typescript-eslint': typescript,
     },
     rules: {
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-unused-vars': 'error',
-      'no-unused-vars': 'off'
+      'no-unused-vars': 'off',
     }
   }
 ];

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -2,11 +2,10 @@ import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import { DATABASE_URL } from "@/config/secrets";
 
-const pool = new Pool({
+export const pool = new Pool({
   connectionString: DATABASE_URL,
 });
 
 const db = drizzle(pool);
 
 export default db;
-export { pool };

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,8 +1,0 @@
-import { integer, pgTable, varchar } from "drizzle-orm/pg-core";
-
-export const usersTable = pgTable("dummyperson", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  name: varchar({ length: 255 }).notNull(),
-  age: integer().notNull(),
-  email: varchar({ length: 255 }).notNull().unique(),
-});

--- a/libs/schema/.env.example
+++ b/libs/schema/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL = "postgresql://user:password@localhost:5432/railguard"

--- a/libs/schema/drizzle.config.ts
+++ b/libs/schema/drizzle.config.ts
@@ -2,8 +2,8 @@ import "dotenv/config";
 import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
-  out: "./drizzle",
-  schema: "./src/db/schema.ts",
+  out: "./migrations",
+  schema: "./src/",
   dialect: "postgresql",
   dbCredentials: {
     url: process.env.DATABASE_URL!,

--- a/libs/schema/eslint.config.js
+++ b/libs/schema/eslint.config.js
@@ -1,0 +1,54 @@
+import js from "@eslint/js";
+import typescript from "@typescript-eslint/eslint-plugin";
+import typescriptParser from "@typescript-eslint/parser";
+
+export default [
+  js.configs.recommended,
+  {
+    files: ["**/*.{ts,d.ts}"],
+    languageOptions: {
+      parser: typescriptParser,
+      globals: {
+        console: "readonly",
+        process: "readonly",
+        Buffer: "readonly",
+        __dirname: "readonly",
+        __filename: "readonly",
+        exports: "writable",
+        module: "writable",
+        require: "readonly",
+        describe: "readonly",
+        it: "readonly",
+        expect: "readonly",
+        test: "readonly",
+      },
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": typescript,
+    },
+    rules: {
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/explicit-function-return-type": "error",
+      "@typescript-eslint/explicit-module-boundary-types": "error",
+
+      "@typescript-eslint/naming-convention": [
+        "error",
+        { selector: "interface", format: ["PascalCase"] },
+        { selector: "typeAlias", format: ["PascalCase"] },
+        { selector: "enum", format: ["PascalCase"] },
+      ],
+
+      "@typescript-eslint/prefer-as-const": "error",
+      "no-unused-expressions": "off",
+      "@typescript-eslint/no-unused-expressions": "error",
+    },
+  },
+  {
+    ignores: ["dist/", "node_modules/", "*.js"],
+  },
+];

--- a/libs/schema/package.json
+++ b/libs/schema/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@railguard/schema",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Centralized schema for the railguard project",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "echo No tests specified && exit 0",
+    "lint": "eslint . --ext .ts",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "dotenv": "^17.2.1",
+    "drizzle-orm": "^0.44.4"
+  },
+  "license": "MIT"
+}

--- a/libs/schema/src/index.ts
+++ b/libs/schema/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./users";

--- a/libs/schema/src/projects.ts
+++ b/libs/schema/src/projects.ts
@@ -1,0 +1,9 @@
+import { uuid, timestamp, varchar, pgTable } from "drizzle-orm/pg-core";
+
+export const projects = pgTable("projects", {
+  id: uuid().primaryKey().defaultRandom(),
+  name: varchar({ length: 255 }).notNull(),
+  owner_id: uuid().notNull(),
+  api_key: uuid().notNull().unique(),
+  created_at: timestamp().defaultNow().notNull(),
+});

--- a/libs/schema/src/users.ts
+++ b/libs/schema/src/users.ts
@@ -1,0 +1,9 @@
+import { uuid, pgTable, varchar, timestamp } from "drizzle-orm/pg-core";
+
+export const users = pgTable("users", {
+  id: uuid().primaryKey(),
+  full_name: varchar({ length: 255 }).notNull(),
+  email: varchar({ length: 255 }).notNull().unique(),
+  password_hash: varchar({ length: 255 }).notNull(),
+  created_at: timestamp().defaultNow().notNull(),
+});

--- a/libs/schema/tsconfig.json
+++ b/libs/schema/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "baseUrl": ".",
+    "declaration": true,
+    "noEmit": false,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,7 +24,7 @@
     "paths": {
       "@railguard/types": ["libs/types/src"],
       "@railguard/design-tokens": ["libs/design-tokens/src"],
-      "@railguard/shared-utils": ["libs/shared-utils/src"]
+      "@railguard/schema": ["libs/schema/src"]
     }
   },
   "include": [],


### PR DESCRIPTION
## PR Description

This PR creates a centralized database schema in the libs folder to enable shared access between the worker, ingestion API and web API.

## Related Issues

Closes #1 

## Summary of Changes

- [x] Add schema package in libs folder
- [x] Add path definition in base tsconfig for accessing from different location
- [x] Create two models users and projects for now
- [x] Configure ESLint but testing is skipped for now
- [x] Move drizzle-kit config from api to schema package
- [x] Add example env
- [x] Export everything from index.ts for better developer experience

## Checklist

- [x] Code follows the project's coding standards.
- [x] All tests pass successfully.
- [ ] Code has been reviewed by at least one other team member.
- [x] The PR is labeled appropriately (e.g., `feature`, `bug`, `refactor`).
- [x] The PR targets the correct branch (e.g., `development`, `main`).

